### PR TITLE
Make <style> tags skippable with attribute

### DIFF
--- a/django_inlinecss/pynliner/__init__.py
+++ b/django_inlinecss/pynliner/__init__.py
@@ -152,6 +152,8 @@ class Pynliner(object):
 
         style_tags = self.soup.findAll('style')
         for tag in style_tags:
+            if tag.get('data-noinline') == 'true':
+                continue
             self.style_string += u'\n'.join(tag.contents) + u'\n'
             tag.extract()
 


### PR DESCRIPTION
With this change you can add a data-noinline="true" attribute to your style tags which then won't get inlined.

We need this for media-query css in our E-Mails.

Example:

``` html
    <style type="text/css" data-noinline="true">
        @media only screen and (max-device-width: 480px) {
          * [class="font-small"] {
            font-size: 20px !important; /* 14px */
          }
        }
    </style>
```
