### PR TITLE
More work on Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ env:
   - DJANGO_VERSION=1.6
 matrix:
   allow_failures:
-    - python: 3.2
-    - python: 3.3
+    - env: "DJANGO_VERSION=1.4"
+      python: 3.2
+    - env: "DJANGO_VERSION=1.4"
+      python: 3.3
 install:
   - pip install -q Django==$DJANGO_VERSION
   - python setup.py -q install

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ template language.
 
 - BeautifulSoup
 - cssutils
-- Python 2.6+
-- Django 1.4+
+- Python 2.6+ and 3.2+
+- Django 1.4+ (1.5+ for 3.X support)
 
 #### Step 2: Install django_inlinecss
 

--- a/django_inlinecss/pynliner/__init__.py
+++ b/django_inlinecss/pynliner/__init__.py
@@ -14,13 +14,14 @@ The generated output of this software shall not be used in a mass marketing serv
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-
 __version__ = "0.4.0"
 
 import urllib2
 import cssutils
 from BeautifulSoup import BeautifulSoup
 from soupselect import select
+
+from six import u
 
 
 class Pynliner(object):
@@ -78,9 +79,9 @@ class Pynliner(object):
         <pynliner.Pynliner object at 0x2ca810>
         """
         if not self.style_string:
-            self.style_string = cssString + u'\n'
+            self.style_string = cssString + u('\n')
         else:
-            self.style_string += cssString + u'\n'
+            self.style_string += cssString + u('\n')
         return self
 
     def run(self):
@@ -126,9 +127,9 @@ class Pynliner(object):
         """Gets <link> element styles
         """
         if not self.style_string:
-            self.style_string = u''
+            self.style_string = u('')
         else:
-            self.style_string += u'\n'
+            self.style_string += u('\n')
 
         link_tags = self.soup.findAll('link', {'rel': 'stylesheet'})
         for tag in link_tags:
@@ -146,13 +147,13 @@ class Pynliner(object):
         """Gets <style> element styles
         """
         if not self.style_string:
-            self.style_string = u''
+            self.style_string = u('')
         else:
-            self.style_string += u'\n'
+            self.style_string += u('\n')
 
         style_tags = self.soup.findAll('style')
         for tag in style_tags:
-            self.style_string += u'\n'.join(tag.contents) + u'\n'
+            self.style_string += u('\n').join(tag.contents) + u('\n')
             tag.extract()
 
     def _get_specificity_from_list(self, lst):
@@ -205,11 +206,10 @@ class Pynliner(object):
                 for prop in prop_list:
                     elem_style_map[elem][prop.name] = prop.value
 
-
         # apply rules to elements
         for elem, style_declaration in elem_style_map.items():
-            if elem.has_key('style'):
-                elem['style'] = u'%s; %s' % (style_declaration.cssText.replace('\n', ' '), elem['style'])
+            if 'style' in elem:
+                elem['style'] = u('%s; %s') % (style_declaration.cssText.replace('\n', ' '), elem['style'])
             else:
                 elem['style'] = style_declaration.cssText.replace('\n', ' ')
 
@@ -221,6 +221,7 @@ class Pynliner(object):
         self.output = unicode(self.soup)
         return self.output
 
+
 def fromURL(url, log=None):
     """Shortcut Pynliner constructor. Equivelent to:
 
@@ -229,6 +230,7 @@ def fromURL(url, log=None):
     Returns processed HTML string.
     """
     return Pynliner(log).from_url(url).run()
+
 
 def fromString(string, log=None):
     """Shortcut Pynliner constructor. Equivelent to:

--- a/django_inlinecss/pynliner/__init__.py
+++ b/django_inlinecss/pynliner/__init__.py
@@ -16,12 +16,13 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 """
 __version__ = "0.4.0"
 
-import urllib2
+from six.moves.urllib.request import urlopen
 import cssutils
-from BeautifulSoup import BeautifulSoup
-from soupselect import select
+from bs4 import BeautifulSoup
+from .soupselect import select
 
 from six import u
+from six import text_type
 
 
 class Pynliner(object):
@@ -104,7 +105,7 @@ class Pynliner(object):
     def _get_url(self, url):
         """Returns the response content from the given url
         """
-        return urllib2.urlopen(url).read()
+        return urlopen(url).read()
 
     def _get_soup(self):
         """Convert source string to BeautifulSoup object. Sets it to self.soup.
@@ -218,7 +219,7 @@ class Pynliner(object):
 
         Returns self.output
         """
-        self.output = unicode(self.soup)
+        self.output = text_type(self.soup)
         return self.output
 
 

--- a/django_inlinecss/pynliner/soupselect.py
+++ b/django_inlinecss/pynliner/soupselect.py
@@ -17,7 +17,7 @@ patched to support multiple class selectors here:
 """
 import re
 import warnings
-import BeautifulSoup
+import bs4 as BeautifulSoup
 
 attribute_regex = re.compile('\[(?P<attribute>\w+)(?P<operator>[=~\|\^\$\*]?)=?["\']?(?P<value>[^\]"]*)["\']?\]')
 pseudo_classes_regexes = (
@@ -243,11 +243,11 @@ def monkeypatch(BeautifulSoupClass=None):
     common import location for BeautifulSoup.
     """
     if not BeautifulSoupClass:
-        from BeautifulSoup import BeautifulSoup as BeautifulSoupClass
+        from bs4 import BeautifulSoup as BeautifulSoupClass
     BeautifulSoupClass.findSelect = select
 
 
 def unmonkeypatch(BeautifulSoupClass=None):
     if not BeautifulSoupClass:
-        from BeautifulSoup import BeautifulSoup as BeautifulSoupClass
+        from bs4 import BeautifulSoup as BeautifulSoupClass
     delattr(BeautifulSoupClass, 'findSelect')

--- a/django_inlinecss/templatetags/inlinecss.py
+++ b/django_inlinecss/templatetags/inlinecss.py
@@ -1,6 +1,6 @@
 from django import template
 
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.conf import settings
@@ -21,7 +21,7 @@ class InlineCssNode(template.Node):
         for expression in self.filter_expressions:
             path = expression.resolve(context, True)
             if path is not None:
-                path = smart_unicode(path)
+                path = smart_text(path)
             if settings.DEBUG:
                 expanded_path = finders.find(path)
             else:

--- a/django_inlinecss/tests/test_pynliner.py
+++ b/django_inlinecss/tests/test_pynliner.py
@@ -4,6 +4,7 @@ import warnings
 import StringIO
 import logging
 import cssutils
+from six import u
 
 from django_inlinecss import pynliner
 from django_inlinecss.pynliner import Pynliner
@@ -27,8 +28,8 @@ class Basic(unittest.TestCase):
         """Test '_get_styles' method"""
         self.p._get_soup()
         self.p._get_styles()
-        self.assertEqual(self.p.style_string, u'h1 { color:#ffcc00; }\n')
-        self.assertEqual(unicode(self.p.soup), u'<h1>Hello World!</h1>')
+        self.assertEqual(self.p.style_string, u('h1 { color:#ffcc00; }\n'))
+        self.assertEqual(unicode(self.p.soup), u('<h1>Hello World!</h1>'))
 
     def test_04_apply_styles(self):
         """Test '_apply_styles' method"""
@@ -37,12 +38,14 @@ class Basic(unittest.TestCase):
         self.p._apply_styles()
         self.assertEqual(
             unicode(self.p.soup),
-            u'<h1 style="color: #fc0">Hello World!</h1>')
+            u('<h1 style="color: #fc0">Hello World!</h1>'))
 
     def test_05_run(self):
         """Test 'run' method"""
         output = self.p.run()
-        self.assertEqual(output, u'<h1 style="color: #fc0">Hello World!</h1>')
+        self.assertEqual(
+            output,
+            u('<h1 style="color: #fc0">Hello World!</h1>'))
 
     def test_06_with_cssString(self):
         """Test 'with_cssString' method"""
@@ -53,12 +56,12 @@ class Basic(unittest.TestCase):
         output = self.p.run()
         self.assertEqual(
             output,
-            u'<h1 style="font-size: 2em; color: #fc0">Hello World!</h1>')
+            u('<h1 style="font-size: 2em; color: #fc0">Hello World!</h1>'))
 
     def test_07_fromString(self):
         """Test 'fromString' complete"""
         output = pynliner.fromString(self.html)
-        desired = u'<h1 style="color: #fc0">Hello World!</h1>'
+        desired = u('<h1 style="color: #fc0">Hello World!</h1>')
         self.assertEqual(output, desired)
 
     def test_08_fromURL(self):
@@ -86,7 +89,7 @@ class Basic(unittest.TestCase):
         p._get_styles()
 
         output = p.run()
-        desired = u"""<?xml version='1.0' encoding='utf-8'?>
+        desired = u("""<?xml version='1.0' encoding='utf-8'?>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>test</title>
@@ -98,7 +101,7 @@ class Basic(unittest.TestCase):
 <p style="color: #999">Possim tincidunt putamus iriure eu nulla. Facer qui volutpat ut aliquam sequitur. Mutationem legere feugiat autem clari notare. Nulla typi augue suscipit lectores in.</p>
 <p style="color: #999">Facilisis claritatem eum decima dignissim legentis. Nulla per legentis odio molestie quarta. Et velit typi claritas ipsum ullamcorper.</p>
 </body>
-</html>"""
+</html>""")
         self.assertEqual(output, desired)
 
     def test_09_overloadedStyles(self):
@@ -133,10 +136,10 @@ class CommaSelector(unittest.TestCase):
         self.p._get_styles()
         self.assertEqual(
             self.p.style_string,
-            u'.b1,.b2 { font-weight:bold; } .c {color: red}\n')
+            u('.b1,.b2 { font-weight:bold; } .c {color: red}\n'))
         self.assertEqual(
             unicode(self.p.soup),
-            u'<span class="b1">Bold</span><span class="b2 c">Bold Red</span>')
+            u('<span class="b1">Bold</span><span class="b2 c">Bold Red</span>'))
 
     def test_04_apply_styles(self):
         """Test '_apply_styles' method"""
@@ -154,7 +157,9 @@ class CommaSelector(unittest.TestCase):
     def test_05_run(self):
         """Test 'run' method"""
         output = self.p.run()
-        self.assertEqual(output, u'<span class="b1" style="font-weight: bold">Bold</span><span class="b2 c" style="color: red; font-weight: bold">Bold Red</span>')
+        self.assertEqual(
+            output,
+            u('<span class="b1" style="font-weight: bold">Bold</span><span class="b2 c" style="color: red; font-weight: bold">Bold Red</span>'))
 
     def test_06_with_cssString(self):
         """Test 'with_cssString' method"""
@@ -163,12 +168,14 @@ class CommaSelector(unittest.TestCase):
         self.assertEqual(self.p.style_string, cssString + '\n')
 
         output = self.p.run()
-        self.assertEqual(output, u'<span class="b1" style="font-size: 2em; font-weight: bold">Bold</span><span class="b2 c" style="color: red; font-size: 2em; font-weight: bold">Bold Red</span>')
+        self.assertEqual(
+            output,
+            u('<span class="b1" style="font-size: 2em; font-weight: bold">Bold</span><span class="b2 c" style="color: red; font-size: 2em; font-weight: bold">Bold Red</span>'))
 
     def test_07_fromString(self):
         """Test 'fromString' complete"""
         output = pynliner.fromString(self.html)
-        desired = u'<span class="b1" style="font-weight: bold">Bold</span><span class="b2 c" style="color: red; font-weight: bold">Bold Red</span>'
+        desired = u('<span class="b1" style="font-weight: bold">Bold</span><span class="b2 c" style="color: red; font-weight: bold">Bold Red</span>')
         self.assertEqual(output, desired)
 
     def test_08_comma_whitespace(self):

--- a/django_inlinecss/tests/test_pynliner.py
+++ b/django_inlinecss/tests/test_pynliner.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 import unittest
 import warnings
-import StringIO
+from six import StringIO
 import logging
 import cssutils
 from six import u
+from six import text_type
 
 from django_inlinecss import pynliner
 from django_inlinecss.pynliner import Pynliner
@@ -22,14 +23,14 @@ class Basic(unittest.TestCase):
     def test_02_get_soup(self):
         """Test '_get_soup' method"""
         self.p._get_soup()
-        self.assertEqual(unicode(self.p.soup), self.html)
+        self.assertEqual(text_type(self.p.soup), self.html)
 
     def test_03_get_styles(self):
         """Test '_get_styles' method"""
         self.p._get_soup()
         self.p._get_styles()
         self.assertEqual(self.p.style_string, u('h1 { color:#ffcc00; }\n'))
-        self.assertEqual(unicode(self.p.soup), u('<h1>Hello World!</h1>'))
+        self.assertEqual(text_type(self.p.soup), u('<h1>Hello World!</h1>'))
 
     def test_04_apply_styles(self):
         """Test '_apply_styles' method"""
@@ -37,7 +38,7 @@ class Basic(unittest.TestCase):
         self.p._get_styles()
         self.p._apply_styles()
         self.assertEqual(
-            unicode(self.p.soup),
+            text_type(self.p.soup),
             u('<h1 style="color: #fc0">Hello World!</h1>'))
 
     def test_05_run(self):
@@ -128,7 +129,7 @@ class CommaSelector(unittest.TestCase):
     def test_02_get_soup(self):
         """Test '_get_soup' method"""
         self.p._get_soup()
-        self.assertEqual(unicode(self.p.soup), self.html)
+        self.assertEqual(text_type(self.p.soup), self.html)
 
     def test_03_get_styles(self):
         """Test '_get_styles' method"""
@@ -138,7 +139,7 @@ class CommaSelector(unittest.TestCase):
             self.p.style_string,
             u('.b1,.b2 { font-weight:bold; } .c {color: red}\n'))
         self.assertEqual(
-            unicode(self.p.soup),
+            text_type(self.p.soup),
             u('<span class="b1">Bold</span><span class="b2 c">Bold Red</span>'))
 
     def test_04_apply_styles(self):
@@ -147,8 +148,8 @@ class CommaSelector(unittest.TestCase):
         self.p._get_styles()
         self.p._apply_styles()
         self.assertEqual(
-            unicode(self.p.soup),
-            unicode(''.join((
+            text_type(self.p.soup),
+            text_type(''.join((
                 '<span class="b1" style="font-weight: bold">Bold</span>',
                 '<span class="b2 c" style="color: red; font-weight: bold">',
                 'Bold Red</span>'))
@@ -215,7 +216,7 @@ class LogOptions(unittest.TestCase):
         self.log = logging.getLogger('testlog')
         self.log.setLevel(logging.DEBUG)
 
-        self.logstream = StringIO.StringIO()
+        self.logstream = StringIO()
         handler = logging.StreamHandler(self.logstream)
         formatter = logging.Formatter(
             "%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -308,9 +309,8 @@ class ComplexSelectors(unittest.TestCase):
         pynliner_instance = Pynliner().from_string(html).with_cssString(css)
         with warnings.catch_warnings(record=True) as warning:
             output = pynliner_instance.run()
-            self.assertEqual(
-                warning[0].message.message,
-                'Pseudoclass :css4-selector invalid or unsupported')
+            self.assertTrue(
+                'Pseudoclass :css4-selector invalid or unsupported' in str(warning[0]))
         self.assertEqual(
             output,
             expected)
@@ -437,9 +437,8 @@ class ComplexSelectors(unittest.TestCase):
         expected = """<h1><a href="/some-url/">Click here</a></h1>"""
         with warnings.catch_warnings(record=True) as warning:
             output = Pynliner().from_string(html).with_cssString(css).run()
-            self.assertEqual(
-                warning[0].message.message,
-                'Pseudoclass :hover invalid or unsupported')
+            self.assertTrue(
+                    'Pseudoclass :hover invalid or unsupported' in str(warning[0]))
         self.assertEqual(output, expected)
 
     def test_attribute_selector_match(self):

--- a/django_inlinecss/tests/test_templatetags.py
+++ b/django_inlinecss/tests/test_templatetags.py
@@ -15,6 +15,7 @@ from django.template import Context
 from django.template.loader import get_template
 
 from mock import patch
+from six import u
 
 from django_inlinecss.tests.constants import TESTS_TEMPLATE_DIR
 from django_inlinecss.tests.constants import TESTS_STATIC_DIR
@@ -126,13 +127,13 @@ class InlineCssTests(TestCase):
         template = get_template('unicode_context_variables.html')
 
         rendered = template.render(Context({
-            'unicode_string': u'I love playing with my pi\xf1ata'}))
+            'unicode_string': u('I love playing with my pi\xf1ata')}))
         self.assertRegexpMatches(
             rendered,
             '<div class="bar" style="padding: 10px 15px 20px 25px">')
         self.assertRegexpMatches(
             rendered,
-            u'I love playing with my pi\xf1ata')
+            u('I love playing with my pi\xf1ata'))
 
     def test_comments_are_ignored(self):
         """

--- a/django_inlinecss/tests/test_templatetags.py
+++ b/django_inlinecss/tests/test_templatetags.py
@@ -14,7 +14,10 @@ from django.utils.safestring import mark_safe
 from django.template import Context
 from django.template.loader import get_template
 
-from mock import patch
+try:
+    from mock import patch
+except ImportError:
+    from unittest.mock import patch
 from six import u
 
 from django_inlinecss.tests.constants import TESTS_TEMPLATE_DIR

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'Django',
         'cssutils',
         'BeautifulSoup',
-        'mock'
+        'mock',
+        'six'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,12 @@ setup(
     install_requires=[
         'Django',
         'cssutils',
-        'BeautifulSoup',
+        'beautifulsoup4',
+        'six',
+        ],
+    tests_require=[
         'mock',
-        'six'
-    ]
+        'six',
+        ],
+    test_suite="run_tests.main",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,54 @@
+[tox]
+envlist =
+    py27-1.4, py27-1.5, py27-1.6,
+    py33-1.5, py33-1.6
+
+[testenv]
+deps = pip
+commands = python setup.py test
+
+[testenv:py27-1.4]
+basepython = python2.7
+deps =
+    {[testenv]deps}
+    Django == 1.4.11
+
+[testenv:py27-1.5]
+basepython = python2.7
+deps =
+    {[testenv]deps}
+    Django == 1.5.6
+
+[testenv:py27-1.6]
+basepython = python2.7
+deps =
+    {[testenv]deps}
+    Django == 1.6.3
+
+[testenv:py27-master]
+basepython = python2.7
+# Temporary django-nose dep: django-nose 1.2 doesn't support django 1.7
+deps =
+    {[testenv]deps}
+    https://github.com/brad/django-nose/tarball/django_1.7
+    https://github.com/django/django/tarball/master
+
+[testenv:py33-1.5]
+basepython = python3.3
+deps =
+    {[testenv]deps}
+    Django == 1.5.6
+
+[testenv:py33-1.6]
+basepython = python3.3
+deps =
+    {[testenv]deps}
+    Django == 1.6.3
+
+[testenv:py33-master]
+basepython = python3.3
+# Temporary django-nose dep: django-nose 1.2 doesn't support django 1.7
+deps =
+    {[testenv]deps}
+    https://github.com/brad/django-nose/tarball/django_1.7
+    https://github.com/django/django/tarball/master


### PR DESCRIPTION
Building on @philipkimmey's work in [this pull request](https://github.com/roverdotcom/django-inlinecss/pull/12), I've switched django-inlinecss to use BeautifulSoup 4, and fixed many minor problems.

The tests now run on at least Python 2.7 and 3.3 without _errors_, although there are many _failures_.  I think this stems from the changes to BeautifulSoup.

Some of the failures seem trivial, like re-ordering of html attributes.  Some are bigger.

It's obviously not ready to merge into master yet, but I wanted to share my start on the work.
