### PR TITLE
Use native open from storage since remote storages don't provide .path()

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ INSTALLED_APPS = (
 </html>
 ```
 
+#### Settings
+
+```
+#avoid using cdn when you have remotes storage systems
+INLINECSS_USE_STATIC_FINDER = False
+```
+
+
 ## Acknowledgements
 
 Thanks to Tanner Netterville for his efforts on [Pynliner](https://github.com/rennat/pynliner).

--- a/django_inlinecss/conf.py
+++ b/django_inlinecss/conf.py
@@ -1,4 +1,4 @@
-from django.utils import importlib
+import importlib
 
 
 DEFAULT_ENGINE = 'django_inlinecss.engines.PynlinerEngine'

--- a/django_inlinecss/templatetags/inlinecss.py
+++ b/django_inlinecss/templatetags/inlinecss.py
@@ -24,10 +24,11 @@ class InlineCssNode(template.Node):
                 path = smart_unicode(path)
             if settings.DEBUG:
                 expanded_path = finders.find(path)
+                css_file = open(expanded_path)
             else:
-                expanded_path = staticfiles_storage.path(path)
+                css_file = staticfiles_storage.open(path)
 
-            with open(expanded_path) as css_file:
+            with css_file:
                 css = ''.join((css, css_file.read()))
 
         engine = conf.get_engine()(html=rendered_contents, css=css)

--- a/django_inlinecss/templatetags/inlinecss.py
+++ b/django_inlinecss/templatetags/inlinecss.py
@@ -22,7 +22,7 @@ class InlineCssNode(template.Node):
             path = expression.resolve(context, True)
             if path is not None:
                 path = smart_unicode(path)
-            if settings.DEBUG:
+            if settings.DEBUG or not getattr(settings, 'INLINECSS_USE_STATIC_FINDER', False):
                 expanded_path = finders.find(path)
                 css_file = open(expanded_path)
             else:


### PR DESCRIPTION
I'm using https://django-storages.readthedocs.org/en/latest/ on my project and django-inlinecss is trying to get an absolute path to non local files 
