### PR TITLE
Use built-in importlib

### DIFF
--- a/django_inlinecss/conf.py
+++ b/django_inlinecss/conf.py
@@ -1,5 +1,7 @@
-from django.utils import importlib
-
+try:
+    import importlib
+except ImportError:
+    from django.utils import importlib
 
 DEFAULT_ENGINE = 'django_inlinecss.engines.PynlinerEngine'
 


### PR DESCRIPTION
 - Django's importlib is deprecated in v1.9. Switching to python's implementation.