### PR TITLE
Change dependency from pynliner3 to pynliner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         ],
     install_requires=[
         'Django',
-        'pynliner3',
+        'pynliner',
         'mock',
     ],
 )


### PR DESCRIPTION
The `pynliner3` package was presumably used while waiting for `pynliner==0.6` to be released, but it is no longer necessary, as `pynliner` is now on v0.7.1.

I also cannot find any references to `pynliner3` anywhere on the internet, except this repo and the PyPI page, so I think it's better to use the maintained version.
