### PR TITLE
Provides Django 1.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ python:
   - 2.7
   - 3.4
 env:
-  - DJANGO_VERSION=1.6
-  - DJANGO_VERSION=1.7
-  - DJANGO_VERSION=1.8
-  - DJANGO_VERSION=1.9
+  - DJANGO_VERSION=1.11
 install:
   - pip install -q Django==$DJANGO_VERSION
   - python setup.py -q install

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ template language.
 - BeautifulSoup
 - cssutils
 - Python 2.7+,3.4+
-- Django 1.6+
+- Django 1.11+
 
 
 #### Step 2: Install django_inlinecss

--- a/django_inlinecss/tests/test_templatetags.py
+++ b/django_inlinecss/tests/test_templatetags.py
@@ -20,15 +20,14 @@ from django_inlinecss.tests.constants import TESTS_TEMPLATE_DIR
 from django_inlinecss.tests.constants import TESTS_STATIC_DIR
 
 
-templates_override = list(settings.TEMPLATE_DIRS) + [TESTS_TEMPLATE_DIR]
+templates_override = list(settings.TEMPLATES) + [TESTS_TEMPLATE_DIR]
 
 
 @override_settings(
-    TEMPLATE_DIRS=templates_override,
     STATIC_ROOT=TESTS_STATIC_DIR)
-class InlineCssTests(TestCase):
+class InlinecssTests(TestCase):
     def setUp(self):
-        super(InlineCssTests, self).setUp()
+        super(InlinecssTests, self).setUp()
 
     def assert_foo_and_bar_rendered(self, rendered):
         foo_div_regex = (
@@ -53,7 +52,7 @@ class InlineCssTests(TestCase):
         to load a CSS file and inline it as part of a rendering step.
         """
         template = get_template('single_staticfiles_css.html')
-        rendered = template.render(Context({}))
+        rendered = template.render({})
         self.assert_foo_and_bar_rendered(rendered)
 
     def test_multiple_staticfiles_css(self):
@@ -63,7 +62,7 @@ class InlineCssTests(TestCase):
         This tests that passing two css files works.
         """
         template = get_template('multiple_staticfiles_css.html')
-        rendered = template.render(Context({}))
+        rendered = template.render({})
         self.assert_foo_and_bar_rendered(rendered)
 
     def test_variable_defined_staticfiles_css(self):
@@ -72,7 +71,7 @@ class InlineCssTests(TestCase):
         may be defined as variables instead of strings.
         """
         template = get_template('variable_defined_staticfiles_css.html')
-        context = Context({'foo_css': 'foo.css', 'bar_css': 'bar.css'})
+        context = {'foo_css': 'foo.css', 'bar_css': 'bar.css'}
 
         rendered = template.render(context)
         self.assert_foo_and_bar_rendered(rendered)
@@ -84,7 +83,7 @@ class InlineCssTests(TestCase):
         """
         template = get_template(
             'variable_and_string_defined_staticfiles_css.html')
-        context = Context({'foo_css': 'foo.css'})
+        context = {'foo_css': 'foo.css'}
         rendered = template.render(context)
         self.assert_foo_and_bar_rendered(rendered)
 
@@ -94,7 +93,7 @@ class InlineCssTests(TestCase):
         content wrapped in the inlinecss block.
         """
         template = get_template('inline_css.html')
-        rendered = template.render(Context({}))
+        rendered = template.render({})
         self.assert_foo_and_bar_rendered(rendered)
 
     def test_context_vars_render_first(self):
@@ -103,9 +102,9 @@ class InlineCssTests(TestCase):
         the inline css step is undertaken.
         """
         template = get_template('context_vars_render_first.html')
-        context = Context({
+        context = {
             'foo_div_open_tag': mark_safe('<div class="foo">'),
-            'bar_div_open_tag': mark_safe('<div class="bar">')})
+            'bar_div_open_tag': mark_safe('<div class="bar">')}
         rendered = template.render(context)
         self.assert_foo_and_bar_rendered(rendered)
 
@@ -115,7 +114,7 @@ class InlineCssTests(TestCase):
         structures.
         """
         template = get_template('template_inheritance.html')
-        rendered = template.render(Context({}))
+        rendered = template.render({})
         self.assert_foo_and_bar_rendered(rendered)
 
     def test_unicode_context_variables(self):
@@ -125,8 +124,8 @@ class InlineCssTests(TestCase):
         """
         template = get_template('unicode_context_variables.html')
 
-        rendered = template.render(Context({
-            'unicode_string': u'I love playing with my pi\xf1ata'}))
+        rendered = template.render({
+            'unicode_string': u'I love playing with my pi\xf1ata'})
         self.assertRegexpMatches(
             rendered,
             '<div class="bar" style="padding: 10px 15px 20px 25px">')
@@ -145,7 +144,7 @@ class InlineCssTests(TestCase):
         """
         template = get_template('comments_are_ignored.html')
 
-        rendered = template.render(Context({}))
+        rendered = template.render({})
         self.assertRegexpMatches(
             rendered,
             '<body>\s+<!-- Here is comment one -->\s+<div')
@@ -158,7 +157,6 @@ class InlineCssTests(TestCase):
 
 
 @override_settings(
-    TEMPLATE_DIRS=templates_override,
     STATIC_ROOT=TESTS_STATIC_DIR)
 class DebugModeStaticfilesTests(TestCase):
     @override_settings(DEBUG=True)
@@ -167,7 +165,7 @@ class DebugModeStaticfilesTests(TestCase):
         full_path = os.path.join(TESTS_STATIC_DIR, "foobar.css")
         find.return_value = full_path
         template = get_template('single_staticfiles_css.html')
-        template.render(Context({}))
+        template.render({})
         find.assert_called_once_with("foobar.css")
 
     @patch('django.contrib.staticfiles.storage.staticfiles_storage.path')
@@ -175,5 +173,5 @@ class DebugModeStaticfilesTests(TestCase):
         full_path = os.path.join(TESTS_STATIC_DIR, "foobar.css")
         path.return_value = full_path
         template = get_template('single_staticfiles_css.html')
-        template.render(Context({}))
+        template.render({})
         path.assert_called_once_with("foobar.css")

--- a/run_tests.py
+++ b/run_tests.py
@@ -29,13 +29,24 @@ def main():
                 'ENGINE': 'django.db.backends.sqlite3',
             }
         },
+        TEMPLATES = [{
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [os.path.join(PROJECT_ROOT,"django_inlinecss","tests","templates"),],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                ],
+            },
+        }],
         STATIC_URL='/static/',
         DEBUG=True
     )
 
-    # Setup Django if 1.7 or greater
-    if django.get_version() >= '1.7':
-        django.setup()
+    django.setup()
     call_command('test', 'django_inlinecss')
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR provides support for Django 1.11 and drop support for previous versions.

There is already a fork that provides support for Django 1.11, but the whole package has been renamed (mailcss) and the licence is not correct (original has been changed).