### PR TITLE
0.2.0 release

### DIFF
--- a/django_inlinecss/__version__.py
+++ b/django_inlinecss/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 1, 2)
+VERSION = (0, 2, 0)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ from __future__ import unicode_literals
 
 import io
 import os
+import sys
+from shutil import rmtree
 
+from setuptools import Command
 from setuptools import find_packages
 from setuptools import setup
 
@@ -72,6 +75,43 @@ else:
     about['__version__'] = VERSION
 
 
+class UploadCommand(Command):
+    """Support setup.py upload."""
+
+    description = 'Build and publish the package.'
+    user_options = []
+
+    @staticmethod
+    def status(s):
+        """Prints things in bold."""
+        print('\033[1m{0}\033[0m'.format(s))
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        try:
+            self.status('Removing previous builds…')
+            rmtree(os.path.join(here, 'dist'))
+        except OSError:
+            pass
+
+        self.status('Building Source and Wheel (universal) distribution…')
+        os.system('{0} setup.py sdist bdist_wheel --universal'.format(sys.executable))
+
+        self.status('Uploading the package to PyPI via Twine…')
+        os.system('twine upload dist/*')
+
+        self.status('Pushing git tags…')
+        os.system('git tag v{0}'.format(about['__version__']))
+        os.system('git push --tags')
+
+        sys.exit()
+
+
 setup(
     name=NAME,
     version=about['__version__'],
@@ -104,4 +144,8 @@ setup(
     install_requires=REQUIRED,
     tests_require=TESTS,
     extras_require=EXTRAS,
+    # $ setup.py upload support.
+    cmdclass={
+        'upload': UploadCommand,
+    },
 )


### PR DESCRIPTION
This branch adds support for the `python setup.py upload` command (from [setup.py for humans](https://github.com/kennethreitz/setup.py)) and bumps the version number to 0.2.0 (because there's a slight incompatibility since we're dropping official support for Django < 1.11.) Once this is approved and merged, I'll run the upload command to tag the release and upload it to pypi.