### PR TITLE
Added explicit encoding to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function


### PR DESCRIPTION
Apparently I can't actually use setup.py unless I add an explicit encoding because my last PR added an ellipses character. This adds the encoding magic comment.