### PR TITLE
README.md: Made Install django_inlinecss instructions more clear.

### DIFF
--- a/.idea/django-inlinecss.iml
+++ b/.idea/django-inlinecss.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/django-inlinecss.iml" filepath="$PROJECT_DIR$/.idea/django-inlinecss.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ template language.
 
 #### Step 2: Install django_inlinecss
 
-Add ```django_inlinecss``` to your ```settings.py```:
+1. Install `django-inlinecss`
+```bash
+pip install django-inlinecss
+```
+2. Add ```django_inlinecss``` to your ```settings.py```:
 
 ```python
 INSTALLED_APPS = (

--- a/README.md
+++ b/README.md
@@ -21,21 +21,20 @@ template language.
 #### Step 2: Install django_inlinecss
 
 1. Install `django-inlinecss`
-```bash
-pip install django-inlinecss
-```
+    ```bash
+    pip install django-inlinecss
+    ```
 2. Add ```django_inlinecss``` to your ```settings.py```:
-
-```python
-INSTALLED_APPS = (
-        'django.contrib.auth',
-        'django.contrib.webdesign',
-        'django.contrib.contenttypes',
-        '...',
-        '...',
-        '...',
-        'django_inlinecss')
-```
+    ```python
+    INSTALLED_APPS = (
+            'django.contrib.auth',
+            'django.contrib.webdesign',
+            'django.contrib.contenttypes',
+            '...',
+            '...',
+            '...',
+            'django_inlinecss')
+    ```
 
 #### Step 3: Use the templatetag
 


### PR DESCRIPTION
Found the instructions to be a bit confusing because installing the `django-inlinecss` package itself was not stated.