### PR TITLE
Configurable CSS Loader

### DIFF
--- a/django_inlinecss/conf.py
+++ b/django_inlinecss/conf.py
@@ -12,10 +12,26 @@ except ImportError:
 DEFAULT_ENGINE = 'django_inlinecss.engines.PynlinerEngine'
 
 
+def load_class_by_path(path):
+    i = path.rfind('.')
+    module_path, class_name = path[:i], path[i + 1:]
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)
+
+
 def get_engine():
     from django.conf import settings
     engine_path = getattr(settings, 'INLINECSS_ENGINE', DEFAULT_ENGINE)
-    i = engine_path.rfind('.')
-    module_path, class_name = engine_path[:i], engine_path[i + 1:]
-    module = importlib.import_module(module_path)
-    return getattr(module, class_name)
+    return load_class_by_path(engine_path)
+
+
+def get_css_loader():
+    from django.conf import settings
+
+    if settings.DEBUG:
+        default_css_loader = 'django_inlinecss.css_loaders.StaticFinderCSSLoader'
+    else:
+        default_css_loader = 'django_inlinecss.css_loaders.StaticPathCSSLoader'
+
+    engine_path = getattr(settings, 'INLINECSS_CSS_LOADER', default_css_loader)
+    return load_class_by_path(engine_path)

--- a/django_inlinecss/conf.py
+++ b/django_inlinecss/conf.py
@@ -10,6 +10,7 @@ except ImportError:
     from django.utils import importlib
 
 DEFAULT_ENGINE = 'django_inlinecss.engines.PynlinerEngine'
+DEFAULT_CSS_LOADER = 'django_inlinecss.css_loaders.StaticfilesStorageCSSLoader'
 
 
 def load_class_by_path(path):
@@ -27,11 +28,5 @@ def get_engine():
 
 def get_css_loader():
     from django.conf import settings
-
-    if settings.DEBUG:
-        default_css_loader = 'django_inlinecss.css_loaders.StaticFinderCSSLoader'
-    else:
-        default_css_loader = 'django_inlinecss.css_loaders.StaticPathCSSLoader'
-
-    engine_path = getattr(settings, 'INLINECSS_CSS_LOADER', default_css_loader)
+    engine_path = getattr(settings, 'INLINECSS_CSS_LOADER', DEFAULT_CSS_LOADER)
     return load_class_by_path(engine_path)

--- a/django_inlinecss/css_loaders.py
+++ b/django_inlinecss/css_loaders.py
@@ -1,0 +1,38 @@
+from django.contrib.staticfiles import finders
+from django.contrib.staticfiles.storage import staticfiles_storage
+
+
+def load_css_by_path(path):
+    with open(path) as css_file:
+        return css_file.read()
+
+
+class BaseCSSLoader(object):
+    def __init__(self):
+        pass
+
+    def load(self, path):
+        """
+        Retrieves the contents of the static asset specified
+        :param path: path to the desired asset
+        :return: contents of asset
+        """
+        raise NotImplementedError()
+
+
+class StaticFinderCSSLoader(BaseCSSLoader):
+    def load(self, path):
+        """
+        Retrieve CSS contents by static finders
+        """
+        expanded_path = finders.find(path)
+        return load_css_by_path(expanded_path)
+
+
+class StaticPathCSSLoader(BaseCSSLoader):
+    def load(self, path):
+        """
+        Retrieve CSS contents by local file system
+        """
+        expanded_path = staticfiles_storage.path(path)
+        return load_css_by_path(expanded_path)

--- a/django_inlinecss/css_loaders.py
+++ b/django_inlinecss/css_loaders.py
@@ -21,6 +21,10 @@ class StaticfilesFinderCSSLoader(BaseCSSLoader):
         Retrieve CSS contents from the local filesystem with static finders
         """
         expanded_path = finders.find(path)
+
+        if expanded_path is None:
+            raise IOError('{} does not exist'.format(path))
+
         with open(expanded_path) as css_file:
             return css_file.read()
 

--- a/django_inlinecss/css_loaders.py
+++ b/django_inlinecss/css_loaders.py
@@ -1,3 +1,8 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.storage import staticfiles_storage
 
@@ -25,8 +30,8 @@ class StaticfilesFinderCSSLoader(BaseCSSLoader):
         if expanded_path is None:
             raise IOError('{} does not exist'.format(path))
 
-        with open(expanded_path) as css_file:
-            return css_file.read()
+        with open(expanded_path, 'rb') as css_file:
+            return css_file.read().decode('utf-8')
 
 
 class StaticfilesStorageCSSLoader(BaseCSSLoader):
@@ -34,4 +39,4 @@ class StaticfilesStorageCSSLoader(BaseCSSLoader):
         """
         Retrieve CSS contents with staticfiles storage
         """
-        return staticfiles_storage.open(path).read()
+        return staticfiles_storage.open(path).read().decode('utf-8')

--- a/django_inlinecss/css_loaders.py
+++ b/django_inlinecss/css_loaders.py
@@ -2,11 +2,6 @@ from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.storage import staticfiles_storage
 
 
-def load_css_by_path(path):
-    with open(path) as css_file:
-        return css_file.read()
-
-
 class BaseCSSLoader(object):
     def __init__(self):
         pass
@@ -20,19 +15,19 @@ class BaseCSSLoader(object):
         raise NotImplementedError()
 
 
-class StaticFinderCSSLoader(BaseCSSLoader):
+class StaticfilesFinderCSSLoader(BaseCSSLoader):
     def load(self, path):
         """
-        Retrieve CSS contents by static finders
+        Retrieve CSS contents from the local filesystem with static finders
         """
         expanded_path = finders.find(path)
-        return load_css_by_path(expanded_path)
+        with open(expanded_path) as css_file:
+            return css_file.read()
 
 
-class StaticPathCSSLoader(BaseCSSLoader):
+class StaticfilesStorageCSSLoader(BaseCSSLoader):
     def load(self, path):
         """
-        Retrieve CSS contents by local file system
+        Retrieve CSS contents with staticfiles storage
         """
-        expanded_path = staticfiles_storage.path(path)
-        return load_css_by_path(expanded_path)
+        return staticfiles_storage.open(path).read()

--- a/django_inlinecss/templatetags/inlinecss.py
+++ b/django_inlinecss/templatetags/inlinecss.py
@@ -27,13 +27,9 @@ class InlineCssNode(template.Node):
             path = expression.resolve(context, True)
             if path is not None:
                 path = smart_text(path)
-            if settings.DEBUG:
-                expanded_path = finders.find(path)
-            else:
-                expanded_path = staticfiles_storage.path(path)
 
-            with open(expanded_path) as css_file:
-                css = ''.join((css, css_file.read()))
+            css_loader = conf.get_css_loader()()
+            css = ''.join((css, css_loader.load(path)))
 
         engine = conf.get_engine()(html=rendered_contents, css=css)
         return engine.render()

--- a/django_inlinecss/templatetags/inlinecss.py
+++ b/django_inlinecss/templatetags/inlinecss.py
@@ -4,9 +4,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django import template
-from django.conf import settings
-from django.contrib.staticfiles import finders
-from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils.encoding import smart_text
 
 from django_inlinecss import conf

--- a/django_inlinecss/tests/test_css_loaders.py
+++ b/django_inlinecss/tests/test_css_loaders.py
@@ -1,37 +1,46 @@
 """
 Test CSS loaders
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.conf import settings
 from django.test import TestCase
+from django.test import override_settings
 
-from django_inlinecss.css_loaders import StaticFinderCSSLoader, StaticPathCSSLoader
+from django_inlinecss.css_loaders import StaticfilesFinderCSSLoader
+from django_inlinecss.css_loaders import StaticfilesStorageCSSLoader
 
 
-class StaticFinderCSSLoaderTestCase(TestCase):
+@override_settings(STATICFILES_DIRS=[settings.STATIC_ROOT], STATIC_ROOT='')
+class StaticfilesFinderCSSLoaderTestCase(TestCase):
     def setUp(self):
-        self.loader = StaticFinderCSSLoader()
-        super(StaticFinderCSSLoaderTestCase, self).setUp()
+        self.loader = StaticfilesFinderCSSLoader()
+        super(StaticfilesFinderCSSLoaderTestCase, self).setUp()
 
-    def test_debug_mode_uses_staticfiles_finder(self):
+    def test_loads_existing_css_file(self):
         css = self.loader.load('bar.css')
         self.assertIn('div.bar {', css)
 
-    def test_load_file_does_not_exists(self):
+    def test_load_file_does_not_exist(self):
         with self.assertRaises(IOError) as e:
             self.loader.load('missing.css')
 
-        self.assertEqual(e.exception.strerror, 'No such file or directory')
+        self.assertEqual(str(e.exception), 'missing.css does not exist')
 
 
-class StaticPathCSSLoaderTestCase(TestCase):
+class StaticfilesStorageCSSLoaderTestCase(TestCase):
     def setUp(self):
-        self.loader = StaticPathCSSLoader()
-        super(StaticPathCSSLoaderTestCase, self).setUp()
+        self.loader = StaticfilesStorageCSSLoader()
+        super(StaticfilesStorageCSSLoaderTestCase, self).setUp()
 
-    def test_load_existing_css_file(self):
+    def test_loads_existing_css_file(self):
         css = self.loader.load('bar.css')
         self.assertIn('div.bar {', css)
 
-    def test_load_file_does_not_exists(self):
+    def test_load_file_does_not_exist(self):
         with self.assertRaises(IOError) as e:
             self.loader.load('missing.css')
 

--- a/django_inlinecss/tests/test_css_loaders.py
+++ b/django_inlinecss/tests/test_css_loaders.py
@@ -1,41 +1,26 @@
 """
 Test CSS loaders
 """
-import os
-
 from django.test import TestCase
-from django.test.utils import override_settings
-
-from mock import patch
-
-from django_inlinecss.tests.constants import TESTS_STATIC_DIR
 from django_inlinecss.css_loaders import StaticFinderCSSLoader, StaticPathCSSLoader
 
 
-@override_settings(STATIC_ROOT=TESTS_STATIC_DIR)
 class StaticFinderCSSLoaderTestCase(TestCase):
     def setUp(self):
         self.loader = StaticFinderCSSLoader()
         super(StaticFinderCSSLoaderTestCase, self).setUp()
 
-    @patch('django.contrib.staticfiles.finders.find')
-    def test_debug_mode_uses_staticfiles_finder(self, find):
-        full_path = os.path.join(TESTS_STATIC_DIR, 'bar.css')
-        find.return_value = full_path
-        css = self.loader.load(full_path)
+    def test_debug_mode_uses_staticfiles_finder(self):
+        css = self.loader.load('bar.css')
         self.assertIn('div.bar {', css)
 
-    @patch('django.contrib.staticfiles.finders.find')
-    def test_load_file_does_not_exists(self, find):
-        full_path = os.path.join(TESTS_STATIC_DIR, 'missing.css')
-        find.return_value = full_path
+    def test_load_file_does_not_exists(self):
         with self.assertRaises(IOError) as e:
             self.loader.load('missing.css')
 
         self.assertEqual(e.exception.strerror, 'No such file or directory')
 
 
-@override_settings(STATIC_ROOT=TESTS_STATIC_DIR)
 class StaticPathCSSLoaderTestCase(TestCase):
     def setUp(self):
         self.loader = StaticPathCSSLoader()

--- a/django_inlinecss/tests/test_css_loaders.py
+++ b/django_inlinecss/tests/test_css_loaders.py
@@ -1,0 +1,52 @@
+"""
+Test CSS loaders
+"""
+import os
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from mock import patch
+
+from django_inlinecss.tests.constants import TESTS_STATIC_DIR
+from django_inlinecss.css_loaders import StaticFinderCSSLoader, StaticPathCSSLoader
+
+
+@override_settings(STATIC_ROOT=TESTS_STATIC_DIR)
+class StaticFinderCSSLoaderTestCase(TestCase):
+    def setUp(self):
+        self.loader = StaticFinderCSSLoader()
+        super(StaticFinderCSSLoaderTestCase, self).setUp()
+
+    @patch('django.contrib.staticfiles.finders.find')
+    def test_debug_mode_uses_staticfiles_finder(self, find):
+        full_path = os.path.join(TESTS_STATIC_DIR, 'bar.css')
+        find.return_value = full_path
+        css = self.loader.load(full_path)
+        self.assertIn('div.bar {', css)
+
+    @patch('django.contrib.staticfiles.finders.find')
+    def test_load_file_does_not_exists(self, find):
+        full_path = os.path.join(TESTS_STATIC_DIR, 'missing.css')
+        find.return_value = full_path
+        with self.assertRaises(IOError) as e:
+            self.loader.load('missing.css')
+
+        self.assertEqual(e.exception.strerror, 'No such file or directory')
+
+
+@override_settings(STATIC_ROOT=TESTS_STATIC_DIR)
+class StaticPathCSSLoaderTestCase(TestCase):
+    def setUp(self):
+        self.loader = StaticPathCSSLoader()
+        super(StaticPathCSSLoaderTestCase, self).setUp()
+
+    def test_load_existing_css_file(self):
+        css = self.loader.load('bar.css')
+        self.assertIn('div.bar {', css)
+
+    def test_load_file_does_not_exists(self):
+        with self.assertRaises(IOError) as e:
+            self.loader.load('missing.css')
+
+        self.assertEqual(e.exception.strerror, 'No such file or directory')

--- a/django_inlinecss/tests/test_css_loaders.py
+++ b/django_inlinecss/tests/test_css_loaders.py
@@ -2,6 +2,7 @@
 Test CSS loaders
 """
 from django.test import TestCase
+
 from django_inlinecss.css_loaders import StaticFinderCSSLoader, StaticPathCSSLoader
 
 

--- a/django_inlinecss/tests/test_templatetags.py
+++ b/django_inlinecss/tests/test_templatetags.py
@@ -28,7 +28,7 @@ class InlinecssTests(TestCase):
             r'<div class="foo" style="margin: 10px 15px 20px 25px">'
             r'\s+This is the "foo" div.\s+'
             r'<\/div>')
-        self.assertRegexpMatches(
+        self.assertRegex(
             rendered,
             foo_div_regex)
 
@@ -36,7 +36,7 @@ class InlinecssTests(TestCase):
             r'<div class="bar" style="padding: 10px 15px 20px 25px">'
             r'\s+This is the "bar" div.\s+'
             r'<\/div>')
-        self.assertRegexpMatches(
+        self.assertRegex(
             rendered,
             bar_div_regex)
 
@@ -120,10 +120,10 @@ class InlinecssTests(TestCase):
 
         rendered = template.render({
             'unicode_string': u'I love playing with my pi\xf1ata'})
-        self.assertRegexpMatches(
+        self.assertRegex(
             rendered,
             '<div class="bar" style="padding: 10px 15px 20px 25px">')
-        self.assertRegexpMatches(
+        self.assertRegex(
             rendered,
             u'I love playing with my pi\xf1ata')
 
@@ -139,13 +139,13 @@ class InlinecssTests(TestCase):
         template = get_template('comments_are_ignored.html')
 
         rendered = template.render({})
-        self.assertRegexpMatches(
+        self.assertRegex(
             rendered,
             r'<body>\s+<!-- Here is comment one -->\s+<div')
-        self.assertRegexpMatches(
+        self.assertRegex(
             rendered,
             r'This is the "foo" div.\s+<!-- comment two -->\s+')
-        self.assertRegexpMatches(
+        self.assertRegex(
             rendered,
             r'This is the "bar" div.\s+<!-- comment three -->\s+')
 

--- a/django_inlinecss/tests/test_templatetags.py
+++ b/django_inlinecss/tests/test_templatetags.py
@@ -150,21 +150,9 @@ class InlinecssTests(TestCase):
             r'This is the "bar" div.\s+<!-- comment three -->\s+')
 
 
-class DebugModeStaticfilesTests(TestCase):
-    @override_settings(DEBUG=True)
-    @patch('django.contrib.staticfiles.finders.find')
-    def test_debug_mode_uses_staticfiles_finder(self, find):
-        full_path = os.path.join(
-            settings.STATIC_ROOT,
-            'foobar.css',
-        )
-        find.return_value = full_path
-        template = get_template('single_staticfiles_css.html')
-        template.render({})
-        find.assert_called_once_with("foobar.css")
-
+class GetLoaderStaticfilesTests(TestCase):
     @patch('django.contrib.staticfiles.storage.staticfiles_storage.path')
-    def test_non_debug_mode_uses_staticfiles_storage(self, path):
+    def test_default_uses_staticfiles_storage(self, path):
         full_path = os.path.join(
             settings.STATIC_ROOT,
             'foobar.css',
@@ -173,3 +161,15 @@ class DebugModeStaticfilesTests(TestCase):
         template = get_template('single_staticfiles_css.html')
         template.render({})
         path.assert_called_once_with("foobar.css")
+
+    @override_settings(INLINECSS_CSS_LOADER='django_inlinecss.css_loaders.StaticfilesFinderCSSLoader')
+    @patch('django.contrib.staticfiles.finders.find')
+    def test_override_uses_staticfiles_finder(self, find):
+        full_path = os.path.join(
+            settings.STATIC_ROOT,
+            'foobar.css',
+        )
+        find.return_value = full_path
+        template = get_template('single_staticfiles_css.html')
+        template.render({})
+        find.assert_called_once_with("foobar.css")


### PR DESCRIPTION
See #31 for background.

This does not change the default behavior for non-DEBUG environments - they will still use the staticfiles storage module. However, this does allow for arbitrary custom css loaders and also corrects some issues with how files are loaded with staticfiles storage.