### PR TITLE
Bumped version number to 0.3.0

### DIFF
--- a/django_inlinecss/__version__.py
+++ b/django_inlinecss/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 2, 0)
+VERSION = (0, 3, 0)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
There is a slight backwards incompatibility because the default behavior for CSS loading if DEBUG=True has changed from using staticfiles finders to using staticfiles storage.