### PR TITLE
Explicitly marked long_description_content_type as markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ setup(
     version=about['__version__'],
     description=DESCRIPTION,
     long_description=long_description,
+    long_description_content_type="text/markdown",
     author=AUTHOR,
     author_email=EMAIL,
     license='MIT',


### PR DESCRIPTION
This is a new requirement for pushing non-RST descriptions to pypi; the new version is rejected if this is not present