### PR TITLE
Remove unnecessary/deprecated apps from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Add ```django_inlinecss``` to your ```settings.py```:
 ```python
 INSTALLED_APPS = (
         'django.contrib.auth',
-        'django.contrib.webdesign',
-        'django.contrib.contenttypes',
         '...',
         '...',
         '...',


### PR DESCRIPTION
Hey! Thanks for the awesome library.

As I was installing this for my own project, I noticed a small problem. The `django.contrib.webdesign` app has been [deprecated](https://docs.djangoproject.com/en/1.8/ref/contrib/webdesign/) since Django 1.8, and including it in the README here could have two negative consequences:

* Given its placement, potential users might think using/installing these Django apps is necessary to use the library, which is not the case
* It might make it seem like the library hasn't been meaningfully updated since Django 1.8, which is also not the case

Hope this is helpful!