### PR TITLE
Replace smart_text with smart_str for Django 4.0 compatibility

### DIFF
--- a/django_inlinecss/__version__.py
+++ b/django_inlinecss/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 3, 0)
+VERSION = (0, 3, 1)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/django_inlinecss/templatetags/inlinecss.py
+++ b/django_inlinecss/templatetags/inlinecss.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django import template
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 from django_inlinecss import conf
 
@@ -23,7 +23,7 @@ class InlineCssNode(template.Node):
         for expression in self.filter_expressions:
             path = expression.resolve(context, True)
             if path is not None:
-                path = smart_text(path)
+                path = smart_str(path)
 
             css_loader = conf.get_css_loader()()
             css = ''.join((css, css_loader.load(path)))


### PR DESCRIPTION
Replace `django.utils.encoding.smart_text` with `django.utils.encoding.smart_str` to make this package compatible with Django 4