### PR TITLE
fixing ResourceWarning: unclosed file error

### DIFF
--- a/django_inlinecss/css_loaders.py
+++ b/django_inlinecss/css_loaders.py
@@ -34,4 +34,6 @@ class StaticfilesStorageCSSLoader(BaseCSSLoader):
         """
         Retrieve CSS contents with staticfiles storage
         """
-        return staticfiles_storage.open(path).read().decode("utf-8")
+        with staticfiles_storage.open(path) as file:
+            return file.read().decode("utf-8")
+


### PR DESCRIPTION
This fixes the warning `ResourceWarning: unclosed file` when using inlinecss in a template