### PR TITLE
Add Django 5.2 support

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8.18, 3.9.18, 3.10.13, 3.11.8]
-        django-version: [3.2, 4.2]
+        python-version: [3.10.13, 3.11.8]
+        django-version: [4.2, 5.2]
 
     name: Lint and Test (Python ${{ matrix.python-version }} - Django ${{ matrix.django-version }})
 

--- a/django_inlinecss/conf.py
+++ b/django_inlinecss/conf.py
@@ -1,7 +1,4 @@
-try:
-    import importlib
-except ImportError:
-    from django.utils import importlib
+import importlib
 
 DEFAULT_ENGINE = "django_inlinecss.engines.PynlinerEngine"
 DEFAULT_CSS_LOADER = "django_inlinecss.css_loaders.StaticfilesStorageCSSLoader"

--- a/django_inlinecss/css_loaders.py
+++ b/django_inlinecss/css_loaders.py
@@ -34,4 +34,5 @@ class StaticfilesStorageCSSLoader(BaseCSSLoader):
         """
         Retrieve CSS contents with staticfiles storage
         """
-        return staticfiles_storage.open(path).read().decode("utf-8")
+        with staticfiles_storage.open(path) as f:
+            return f.read().decode("utf-8")

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ VERSION = None
 REQUIRED = [
     'Django>=3.2',
     'pynliner',
-    'future>=0.16.0',
 ]
 
 # What packages are required only for tests?
@@ -121,9 +120,11 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Framework :: Django",
+        "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.2",
         "Topic :: Communications :: Email",
         "Topic :: Text Processing :: Markup :: HTML",
     ],

--- a/test_settings.py
+++ b/test_settings.py
@@ -117,8 +117,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 


### PR DESCRIPTION
## Summary
- Add Django 5.2 to CI matrix and drop unsupported Python 3.8/3.9 and Django 3.2
- Remove dead `django.utils.importlib` fallback in `conf.py`
- Remove unused `future` dependency
- Fix unclosed file handle in `StaticfilesStorageCSSLoader`
- Remove deprecated `USE_L10N` setting from test config

Verified in web PR